### PR TITLE
Speedup by storing the computation of the square root of C[i,i]/C[j,j]

### DIFF
--- a/src/ledoitwolf.jl
+++ b/src/ledoitwolf.jl
@@ -24,7 +24,7 @@ O. Ledoit and M. Wolf, “Honey, I Shrunk the Sample Covariance Matrix,”
 The Journal of Portfolio Management, vol. 30, no. 4, pp. 110–119, Jul. 2004.
 """
 function cov(::LedoitWolfCovariance, X::DenseMatrix{T}, shrinkage::Number) where T<:Real
-    (shrinkage ≥ 0 && shrinkage ≤ 1) || throw(ArgumentError("Shinkage must be in [0,1] (given shrinkage: $shrinkage)"))
+    (0 ≤ shrinkage ≤ 1) || throw(ArgumentError("Shinkage must be in [0,1] (given shrinkage: $shrinkage)"))
     C = cov(X; dims=2)
     F, r̄ = ledoitwolfshrinkagetarget(C)
     (1-shrinkage)*C + shrinkage*F
@@ -53,7 +53,8 @@ function cov(::LedoitWolfCovariance, X::DenseMatrix{T}) where T<:Real
     #TODO: inbounds/simd?
     for i in 1:N
         for j in 1:N
-            ρhatpart2 += sqrt(C[j,j]/C[i,i])*ϑhatii[i,j] + sqrt(C[i,i]/C[j,j])*ϑhatjj[i,j]
+            αij = sqrt(C[j,j]/C[i,i])
+            ρhatpart2 += ϑhatii[i,j]*αij + ϑhatjj[i,j]/αij
         end
     end
     ρhat = sum(diag(πmatrix)) + (r̄/2)*ρhatpart2

--- a/src/ledoitwolf.jl
+++ b/src/ledoitwolf.jl
@@ -51,9 +51,10 @@ function cov(::LedoitWolfCovariance, X::DenseMatrix{T}) where T<:Real
     ϑhatjj = mean([(X[i,t]^2 - C[j,j])*(X[i,t]*X[j,t] - C[i,j]) for i in 1:N, j in 1:N] for t in 1:Tnum)
     ρhatpart2 = zero(T)
     #TODO: inbounds/simd?
+    sdC = sqrt.(C[i,i] for i ∈ 1:N)
     for i in 1:N
         for j in 1:N
-            αij = sqrt(C[j,j]/C[i,i])
+            αij = sdC[j]/sdC[i]
             ρhatpart2 += ϑhatii[i,j]*αij + ϑhatjj[i,j]/αij
         end
     end


### PR DESCRIPTION
E.g. simple benchmark:

```julia
using BenchmarkTools

function foo(X)
    N = size(X, 1)
    a = 0.
    for i ∈ 1:N
        for j ∈ 1:N
            a += sqrt(X[i, i]/X[j, j]) * X[i,j] + X[j,i] * sqrt(X[j, j]/X[i, i])
        end
    end
    a
end

function bar(X)
   N = size(X, 1)
   a = 0.
   for i ∈ 1:N
       for j ∈ 1:N
           aij = sqrt(X[i,i]/X[j,j])
           a += aij * X[i, j] + X[j, i] / aij
       end
   end
   a
end

XX = rand(500, 1000);

@btime foo($XX) # 1.4ms 
@btime bar($XX) # 1.0ms
```
