### PR TITLE
performance improvements for linearshrinkage

### DIFF
--- a/src/linearshrinkage.jl
+++ b/src/linearshrinkage.jl
@@ -111,15 +111,17 @@ end
 # helper function to compute ∑_{i≂̸j} f_ij  that appears in
 # http://strimmerlab.org/publications/journals/shrinkcov2005.pdf p 11
 """
-    sum_fij(Xc, S, )
+    sum_fij(Xc, S, n, κ)
+
+Internal function corresponding to ``∑_{i≂̸j}f_{ij}`` that appears in
+http://strimmerlab.org/publications/journals/shrinkcov2005.pdf p.11.
 """
-function sum_fij(Xc, S, n, p, corrected=false)
-    κ  = n - Int(corrected)
-    sd = sqrt.(diag(S))
-    M1 = ((Xc.^3)'*Xc)./ sd
-    M2 = κ * S .* sd
-    M3 = (M1 - M2) .* sd'
-    return sumij(M3) / (n*κ)
+function sum_fij(Xc, S, n, κ)
+    sd  = sqrt.(diag(S))
+    M   = ((Xc.^3)'*Xc) ./ sd
+    M .-= κ * S .* sd
+    M .*= sd'
+    return sumij(M) / (n * κ)
 end
 ##############################################################################
 
@@ -297,7 +299,7 @@ function linear_shrinkage(::PerfectPositiveCorrelation, Xc::AbstractMatrix,
     if λ ∈ [:auto, :lw]
         ΣS̄² = γ^2 * sumij2(S)
         λ   = (sumij(uccov(Xc²)) - ΣS̄²) / κ
-        λ  -= sum_fij(Xc, S, n, p, corrected)
+        λ  -= sum_fij(Xc, S, n, κ)
         λ  /= sumij2(S - F)
     else
         error("Unsupported shrinkage method for target DiagonalCommonVariance.")
@@ -337,7 +339,7 @@ function linear_shrinkage(::ConstantCorrelation, Xc::AbstractMatrix,
     if λ ∈ [:auto, :lw]
         ΣS̄² = γ^2 * sumij2(S)
         λ   = (sumij(uccov(Xc²)) - ΣS̄²) / κ
-        λ  -= r̄ * sum_fij(Xc, S, n, p, corrected)
+        λ  -= r̄ * sum_fij(Xc, S, n, κ)
         λ  /= sumij2(S - F)
     else
         error("Unsupported shrinkage method for target DiagonalCommonVariance.")

--- a/src/linearshrinkage.jl
+++ b/src/linearshrinkage.jl
@@ -187,13 +187,13 @@ function linear_shrinkage(::DiagonalCommonVariance, Xc::AbstractMatrix,
         trS² = sum(S.^2)
         tr²S = tr(S)^2
         # note: using corrected or uncorrected S does not change λ
-        λ = ((n-2)/n * trS² + tr²S)/((n+2) * (trS² - tr²S/p))
+        λ = ((n-2)/n * trS² + tr²S) / ((n+2) * (trS² - tr²S/p))
     elseif λ == :oas
         # https://arxiv.org/pdf/0907.4698.pdf equation 23
         trS² = sum(S.^2)
         tr²S = tr(S)^2
         # note: using corrected or uncorrected S does not change λ
-        λ = ((1.0-2.0/p) * trS² + tr²S)/((n+1.0-2.0/p) * (trS² - tr²S/p))
+        λ = ((1.0-2.0/p) * trS² + tr²S) / ((n+1.0-2.0/p) * (trS² - tr²S/p))
     else
         error("Unsupported shrinkage method for target DiagonalCommonVariance.")
     end
@@ -240,9 +240,9 @@ end
 ## TARGET C
 
 function target_C(S::AbstractMatrix, p::Int)
-    v = tr(S)/p
-    c = sumij(S; with_diag=false) / (p * (p - 1))
-    F = c * ones(p, p)
+    v  = tr(S)/p
+    c  = sumij(S; with_diag=false) / (p * (p - 1))
+    F  = c * ones(p, p)
     F -= Diagonal(F)
     F += v * I
     return F, v, c
@@ -279,8 +279,8 @@ end
 ## TARGET E
 
 function target_E(S::AbstractMatrix)
-    d = diag(S)
-    return sqrt.(d*d')
+    d = sqrt.(diag(S))
+    return d*d'
 end
 
 function linear_shrinkage(::PerfectPositiveCorrelation, Xc::AbstractMatrix,
@@ -303,7 +303,7 @@ function linear_shrinkage(::PerfectPositiveCorrelation, Xc::AbstractMatrix,
         ΣS̄² = γ^2 * sumij2(S)
         λ   = (sumij(uccov(Xc²)) - ΣS̄²) / κ
         λ  -= sum_fij(Xc, S, n, p, corrected)
-        λ  /= sumij2((S - F))
+        λ  /= sumij2(S - F)
     else
         error("Unsupported shrinkage method for target DiagonalCommonVariance.")
     end
@@ -315,8 +315,8 @@ end
 
 function target_F(S::AbstractMatrix, p::Int)
     s  = sqrt.(diag(S))
-    s_ = @inbounds [s[i]*s[j] for i ∈ 1:p, j ∈ 1:p]
-    r̄  = (sum(S ./ s_) - p)/(p * (p - 1))
+    s_ = s*s'
+    r̄  = (sum(S ./ s_) - p) / (p * (p - 1))
     F_ = r̄ * s_
     F  = F_ + (Diagonal(s_) - Diagonal(F_))
     return F, r̄
@@ -343,7 +343,7 @@ function linear_shrinkage(::ConstantCorrelation, Xc::AbstractMatrix,
         ΣS̄² = γ^2 * sumij2(S)
         λ   = (sumij(uccov(Xc²)) - ΣS̄²) / κ
         λ  -= r̄ * sum_fij(Xc, S, n, p, corrected)
-        λ  /= sumij2((S - F))
+        λ  /= sumij2(S - F)
     else
         error("Unsupported shrinkage method for target DiagonalCommonVariance.")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,7 +173,7 @@ end
         d = diag(S)
         F = sqrt.(d*d')
         shrinkage  = sum_var_sij(Xtmp, S, n; with_diag=false)
-        shrinkage -= CE.sum_fij(Xtmp, S, n, p)
+        shrinkage -= CE.sum_fij(Xtmp, S, n, n)
         shrinkage /= sum((S - F).^2)
         shrinkage = clamp(shrinkage, 0.0, 1.0)
         @test cov(X̂, lwe) ≈ (1.0-shrinkage) * S + shrinkage * F


### PR DESCRIPTION
I don't think this requires much of a discussion

* added docstrings for internal functions `sumij, rescale, square, sumij2`
* added `sumij2` to pass the squaring to the sum function so that it does not allocate `S.^2`, significantly faster
* modified `rescale` from `D*M*D` to `M .*d .* d'` which does not require the formation of `D` and is what is computed anyway, also ends up being faster
* fixed a target which was computed as `sqrt.(d*d')` replacing by `d = sqrt.(d); d*d'` which requires only `p` square roots as opposed to `p^2`... 
* fixed the computation of the target of `F` by just using the outer product of `s`

(I still need to fix #30 but it'll require a bit more thinking)