### PR TITLE
fix for #63

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,10 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
+[compat]
+StatsBase = ">= 0.29"
+julia = "1.0"
+
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -15,7 +19,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Random", "DelimitedFiles"]
-
-[compat]
-julia = "1.0"
-StatsBase = ">= 0.29"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 
 *Lightweight robust covariance estimation in Julia.*
 
-A package for estimating covariance matrices.
+A package for robustly estimating covariance matrices of real-valued data.
 
 ## Package Features
 

--- a/src/nonlinearshrinkage.jl
+++ b/src/nonlinearshrinkage.jl
@@ -105,7 +105,7 @@ function analytical_nonlinear_shrinkage(S::AbstractMatrix{<:Real},
     end
 
     # Equation (4.4)
-    return U*(d̃ .* U')
+    return Symmetric(U*(d̃ .* U'))
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,11 @@
 function linshrink(F::Union{UniformScaling, AbstractMatrix},
                    S::AbstractMatrix, λ::Real)
-    return (1.0 - λ)*S + λ*F
+    return Symmetric((1.0 - λ)*S + λ*F)
 end
 
 
 function linshrink!(F::AbstractMatrix, S::AbstractMatrix, λ::Real)
     F .*= λ
-    F .+= (1.0 - λ) * S
-    return F
+    F .+= (1.0 - λ)*S
+    return Symmetric(F)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,12 +6,10 @@ using Random
 using DelimitedFiles
 using StatsBase
 
-
 include("ref_lw_lshrink.jl")
 include("ref_lw_nlshrink.jl")
 include("legacy.jl")
 Random.seed!(1234)
-
 
 const CE = CovarianceEstimation
 

--- a/test/test_linearshrinkage.jl
+++ b/test/test_linearshrinkage.jl
@@ -7,8 +7,8 @@
     for X̂ ∈ test_matrices
         ref_results = matlab_ledoitwolf_covcor(X̂)
         lwfixed = LinearShrinkage(ConstantCorrelation(), ref_results["shrinkage"])
-        @test cov(lw, X̂) ≈ ref_results["lwcov"]
-        @test cov(lwfixed, X̂) ≈ ref_results["lwcov"]
+        c = cov(lw, X̂); @test c ≈ ref_results["lwcov"]; @test issymmetric(c)
+        c = cov(lwfixed, X̂); @test c ≈ ref_results["lwcov"]; @test issymmetric(c)
     end
 end
 
@@ -32,9 +32,9 @@ end
     ref_cov2  = readdlm(joinpath(p, "test_matrices/100x20_corpcor.csv"))
     test_mat3 = readdlm(joinpath(p, "test_matrices/50x50.csv"))
     ref_cov3  = readdlm(joinpath(p, "test_matrices/50x50_corpcor.csv"))
-    @test cov(ss, test_mat1) ≈ ref_cov1
-    @test cov(ss, test_mat2) ≈ ref_cov2
-    @test cov(ss, test_mat3) ≈ ref_cov3
+    c = cov(ss, test_mat1); @test c ≈ ref_cov1; @test issymmetric(c)
+    c = cov(ss, test_mat2); @test c ≈ ref_cov2; @test issymmetric(c)
+    c = cov(ss, test_mat3); @test c ≈ ref_cov3; @test issymmetric(c)
 end
 
 
@@ -48,9 +48,10 @@ end
         shrinkage  = sum_var_sij(Xtmp, S, n)
         shrinkage /= sum((S-Diagonal(S)).^2) + sum((diag(S).-1).^2)
         shrinkage = clamp(shrinkage, 0.0, 1.0)
-        @test cov(lwa, X̂) ≈ (1.0-shrinkage) * S + shrinkage * I
+        c = cov(lwa, X̂); @test c ≈ (1.0-shrinkage) * S + shrinkage * I; @test issymmetric(c)
         lwafixed = LinearShrinkage(DiagonalUnitVariance(), shrinkage)
-        @test cov(lwafixed, X̂) ≈ (1.0 - shrinkage) * S + shrinkage * I
+        c = cov(lwafixed, X̂); @test c ≈ (1.0 - shrinkage) * S + shrinkage * I
+        @test issymmetric(c)
     end
     # TARGET B
     lwb = LinearShrinkage(DiagonalCommonVariance())
@@ -63,9 +64,10 @@ end
         shrinkage  = sum_var_sij(Xtmp, S, n)
         shrinkage /= sum((S-Diagonal(S)).^2) + sum((diag(S).-v).^2)
         shrinkage = clamp(shrinkage, 0.0, 1.0)
-        @test cov(lwb, X̂) ≈ (1.0-shrinkage) * S + shrinkage * F
+        c = cov(lwb, X̂); @test c ≈ (1.0-shrinkage) * S + shrinkage * F; @test issymmetric(c)
         lwbfixed = LinearShrinkage(DiagonalCommonVariance(), shrinkage)
-        @test cov(lwbfixed, X̂) ≈ (1.0 - shrinkage) * S + shrinkage * F
+        c = cov(lwbfixed, X̂); @test c ≈ (1.0 - shrinkage) * S + shrinkage * F
+        @test issymmetric(c)
     end
     # TARGET C
     lwc = LinearShrinkage(CommonCovariance())
@@ -79,9 +81,9 @@ end
         shrinkage  = sum_var_sij(Xtmp, S, n)
         shrinkage /= sum(((S-Diagonal(S)) - c*(ones(p, p)-I)).^2) + sum((diag(S) .- v).^2)
         shrinkage = clamp(shrinkage, 0.0, 1.0)
-        @test cov(lwc, X̂) ≈ (1.0-shrinkage) * S + shrinkage * F
+        c = cov(lwc, X̂); @test c ≈ (1.0-shrinkage) * S + shrinkage * F; @test issymmetric(c)
         lwcfixed = LinearShrinkage(CommonCovariance(), shrinkage)
-        @test cov(lwcfixed, X̂) ≈ (1.0-shrinkage) * S + shrinkage * F
+        c = cov(lwcfixed, X̂); @test  c ≈ (1.0-shrinkage) * S + shrinkage * F; @test issymmetric(c)
     end
     # TARGET D
     lwd = LinearShrinkage(DiagonalUnequalVariance())
@@ -93,9 +95,9 @@ end
         shrinkage  = sum_var_sij(Xtmp, S, n, false; with_diag=false)
         shrinkage /= sum((S-Diagonal(S)).^2)
         shrinkage = clamp(shrinkage, 0.0, 1.0)
-        @test cov(lwd, X̂) ≈ (1.0-shrinkage) * S + shrinkage * F
+        c = cov(lwd, X̂); @test c ≈ (1.0-shrinkage) * S + shrinkage * F; @test issymmetric(c)
         lwdfixed = LinearShrinkage(DiagonalUnequalVariance(), shrinkage)
-        @test cov(lwdfixed, X̂) ≈ (1.0-shrinkage) * S + shrinkage * F
+        c = cov(lwdfixed, X̂); @test c ≈ (1.0-shrinkage) * S + shrinkage * F; @test issymmetric(c)
     end
     # TARGET E
     lwe = LinearShrinkage(PerfectPositiveCorrelation())
@@ -109,9 +111,9 @@ end
         shrinkage -= CE.sum_fij(Xtmp, S, n, n)
         shrinkage /= sum((S - F).^2)
         shrinkage = clamp(shrinkage, 0.0, 1.0)
-        @test cov(lwe, X̂) ≈ (1.0-shrinkage) * S + shrinkage * F
+        c = cov(lwe, X̂); @test c ≈ (1.0-shrinkage) * S + shrinkage * F; @test issymmetric(c)
         lwefixed = LinearShrinkage(PerfectPositiveCorrelation(), shrinkage)
-        @test cov(lwefixed, X̂) ≈ (1.0-shrinkage) * S + shrinkage * F
+        c = cov(lwefixed, X̂); @test c ≈ (1.0-shrinkage) * S + shrinkage * F; @test issymmetric(c)
     end
 end
 
@@ -145,13 +147,14 @@ end
         λ_oas_ref = ((1-2/p)*tr(Ŝ^2)+tr(Ŝ)^2)/((n+1-2/p)*(tr(Ŝ^2)-tr(Ŝ)^2/p))
         λ_oas_ref = clamp(λ_oas_ref, 0.0, 1.0)
 
-        @test cov(rblw, X̂) ≈ CE.linshrink(F_ref, Ŝ, λ_rblw_ref)
-        @test cov(oas, X̂) ≈ CE.linshrink(F_ref, Ŝ, λ_oas_ref)
+        c = cov(rblw, X̂); @test c ≈ CE.linshrink(F_ref, Ŝ, λ_rblw_ref); @test issymmetric(c)
+        c = cov(oas, X̂); @test c ≈ CE.linshrink(F_ref, Ŝ, λ_oas_ref); @test issymmetric(c)
 
         rblw_fixed = LinearShrinkage(DiagonalCommonVariance(), λ_rblw_ref)
         oas_fixed = LinearShrinkage(DiagonalCommonVariance(), λ_oas_ref)
-        @test cov(rblw_fixed, X̂) ≈ CE.linshrink(F_ref, Ŝ, λ_rblw_ref)
-        @test cov(oas_fixed, X̂) ≈ CE.linshrink(F_ref, Ŝ, λ_oas_ref)
+        c = cov(rblw_fixed, X̂); @test c ≈ CE.linshrink(F_ref, Ŝ, λ_rblw_ref)
+        @test issymmetric(c)
+        c = cov(oas_fixed, X̂); @test c ≈ CE.linshrink(F_ref, Ŝ, λ_oas_ref); @test issymmetric(c)
     end
 end
 
@@ -178,7 +181,7 @@ end
             end
             LSEss = LinearShrinkage(target, :ss, corrected=c)
             LSElw = LinearShrinkage(target, :lw, corrected=c)
-            @test cov(LSEss, Xcs) ≈ cov(LSElw, Xcs)
+            c = cov(LSEss, Xcs); @test c ≈ cov(LSElw, Xcs); @test issymmetric(c)
             # weights are not currently exported but it seems to be a good
             # idea to ensure proper errors
             fw1 = FrequencyWeights(rand(1:10, size(Xcs, 1)))
@@ -205,8 +208,10 @@ end
             LSEss = LinearShrinkage(target, :ss, corrected=c)
             LSElw = LinearShrinkage(target, :lw, corrected=c)
             m = mean(cov(LSEss, Xcs, dims=dim, mean=nothing))
-            @test cov(LSEss, Xcs, dims=dim, mean=mean(Xcs, dims=dim)) ≈ cov(LSEss, Xcs, dims=dim, mean=nothing)
-            @test cov(LSElw, Xcs, dims=dim, mean=mean(Xcs, dims=dim)) ≈ cov(LSElw, Xcs, dims=dim, mean=nothing)
+            c = cov(LSEss, Xcs, dims=dim, mean=mean(Xcs, dims=dim));
+            @test c ≈ cov(LSEss, Xcs, dims=dim, mean=nothing); @test issymmetric(c)
+            c = cov(LSElw, Xcs, dims=dim, mean=mean(Xcs, dims=dim));
+            @test c ≈ cov(LSElw, Xcs, dims=dim, mean=nothing); @test issymmetric(c)
             if dim == 2
                 meanvec = vec(mean(Xcs, dims=dim))
                 @test cov(LSEss, Xcs, dims=dim, mean=meanvec) ≈ cov(LSEss, Xcs, dims=dim, mean=nothing)

--- a/test/test_nonlinearshrinkage.jl
+++ b/test/test_nonlinearshrinkage.jl
@@ -3,7 +3,8 @@
     for X̂ ∈ test_matrices
         size(X̂, 1) < 12 && continue
         ref_result = matlab_ledoitwolf_analytical_shrinkage(X̂)
-        @test cov(ANS, X̂) ≈ ref_result
+        c = cov(ANS, X̂); @test c ≈ ref_result
+        @test issymmetric(c)
     end
 
     # weights are not currently exported but it seems to be a good


### PR DESCRIPTION
* makes all returned matrices symmetric
* add tests more or less everywhere that things are symmetric

**Note**: following comment in the issue, I had a quick look at what happened when data was complex and initially had a condition for `linshrink` whereby if `eltype(F)<:Complex` it returned `Hermitian(...)` but in fact, our package simply does not yet work with Complex valued data.  I changed the blurb in the doc to make sure this was clear that it was for real-valued data. 

To see why it's a bit tricky, have a look at the simple linear shrinkage LW, the `\lambda`  computation is not valid for complex valued data; you end up with a complex valued lambda. Maybe that similar LW formulas can be obtained for complex valued data but that would likely require a bit of effort and maybe it's simply not worth it here atm 🙂 