### PR TITLE
use fused broadcasting in core linshrink operation

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,6 +5,6 @@ end
 
 
 function linshrink!(F::AbstractMatrix, S::AbstractMatrix, λ::Real)
-    F .= (1.0 .- λ).*S .+ λ.*F)
+    F .= (1.0 .- λ).*S .+ λ.*F
     return Symmetric(F)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,10 @@
 function linshrink(F::Union{UniformScaling, AbstractMatrix},
                    S::AbstractMatrix, λ::Real)
-    return Symmetric((1.0 - λ)*S + λ*F)
+    return Symmetric((1.0 .- λ).*S .+ λ.*F)
 end
 
 
 function linshrink!(F::AbstractMatrix, S::AbstractMatrix, λ::Real)
-    F .*= λ
-    F .+= (1.0 - λ)*S
+    F .= (1.0 .- λ).*S .+ λ.*F)
     return Symmetric(F)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,10 @@
-function linshrink(F::Union{UniformScaling, AbstractMatrix},
-                   S::AbstractMatrix, λ::Real)
+function linshrink(F::AbstractMatrix, S::AbstractMatrix, λ::Real)
     return Symmetric((1.0 .- λ).*S .+ λ.*F)
 end
 
+function linshrink(F::UniformScaling, S::AbstractMatrix, λ::Real)
+    return Symmetric((1.0 .- λ).*S + λ.*F)
+end
 
 function linshrink!(F::AbstractMatrix, S::AbstractMatrix, λ::Real)
     F .= (1.0 .- λ).*S .+ λ.*F


### PR DESCRIPTION
This will avoid allocating temporaries for these operations,
making them allocate less and be faster