### PR TITLE
Update link for Schäfer & Strimmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ These benchmarks should (as usual) be taken with a pinch of salt but essentially
 
 ## References
 
-* [**1**] J. Schäfer and K. Strimmer, *[A Shrinkage Approach to Large-Scale Covariance Matrix Estimation and Implications for Functional Genomics](http://strimmerlab.org/publications/journals/shrinkcov2005.pdf)*, Statistical Applications in Genetics and Molecular Biology, 2005.
+* [**1**] J. Schäfer and K. Strimmer, *[A Shrinkage Approach to Large-Scale Covariance Matrix Estimation and Implications for Functional Genomics](https://strimmerlab.github.io/publications/journals/shrinkcov2005.pdf)*, Statistical Applications in Genetics and Molecular Biology, 2005.
 * [**2**] O. Ledoit and M. Wolf, *[Honey, I Shrunk the Sample Covariance Matrix](http://www.ledoit.net/honey.pdf)*, The Journal of Portfolio Management, 2004.
 * [**3**] Y. Chen, A. Wiesel, Y. C. Eldar, and A. O. Hero, *[Shrinkage Algorithms for MMSE Covariance Estimation](https://arxiv.org/pdf/0907.4698.pdf)*, IEEE Transactions on Signal Processing, 2010.
 * [**4**] O. Ledoit and M. Wolf, *[Analytical Nonlinear Shrinkage of Large-Dimensional Covariance Matrices](http://www.econ.uzh.ch/static/wp/econwp264.pdf)*, Working Paper, 2018.

--- a/docs/src/man/lshrink.md
+++ b/docs/src/man/lshrink.md
@@ -10,7 +10,7 @@ where $F$ is a *target* matrix of appropriate dimensions, $\lambda\in[0,1]$ is a
 
 ## Targets and intensities
 
-There are several standard target matrices (denoted by $F$) that can be used (we follow here the notations and naming conventions of [Schaffer & Strimmer 2005](http://strimmerlab.org/publications/journals/shrinkcov2005.pdf)):
+There are several standard target matrices (denoted by $F$) that can be used (we follow here the notations and naming conventions of [Schaffer & Strimmer 2005](https://strimmerlab.github.io/publications/journals/shrinkcov2005.pdf)):
 
 
 | Target name | $F_{ii}$     | $F_{ij}$ ($i\neq j$) | Comment   |
@@ -23,12 +23,12 @@ There are several standard target matrices (denoted by $F$) that can be used (we
 | `ConstantCorrelation` | $S_{ii}$ | $\overline{r}\sqrt{S_{ii}S_{jj}}$ | used in [Ledoit & Wolf 2004](http://www.ledoit.net/honey.pdf) |
 
 
-where $ v = \mathrm{tr}(S)/p $ is the average variance, $c = \sum_{i\neq j} S_{ij}/(p(p-1))$ is the average of off-diagonal terms of $S$ and $\overline{r}$ is the average of sample correlations (see [Schaffer & Strimmer 2005](http://strimmerlab.org/publications/journals/shrinkcov2005.pdf)).
+where $ v = \mathrm{tr}(S)/p $ is the average variance, $c = \sum_{i\neq j} S_{ij}/(p(p-1))$ is the average of off-diagonal terms of $S$ and $\overline{r}$ is the average of sample correlations (see [Schaffer & Strimmer 2005](https://strimmerlab.github.io/publications/journals/shrinkcov2005.pdf)).
 
 For each of these targets, an optimal shrinkage intensity $\lambda^\star$ can be computed.
 A standard approach is to apply the Ledoit-Wolf formula (`shrinkage=:lw`, see [Ledoit & Wolf 2004](http://www.ledoit.net/honey.pdf)) though there are some variants that can be applied too.
 Notably, Schaffer & Strimmer's variant (`shrinkage=:ss`) will ensure that the $\lambda^\star$ computed is the same for $X_c$ (the centered data matrix) as for $X_s$ (the standardised data matrix).
-See [Schaffer & Strimmer 2005](http://strimmerlab.org/publications/journals/shrinkcov2005.pdf).
+See [Schaffer & Strimmer 2005](https://strimmerlab.github.io/publications/journals/shrinkcov2005.pdf).
 
 Chen's variant includes a Rao-Blackwellised estimator (`shrinkage=:rblw`) and an Oracle-Approximating one (`shrinkage=:oas`) for the `DiagonalCommonVariance` target.
 See [Chen, Wiesel, Eldar & Hero 2010](https://arxiv.org/pdf/0907.4698.pdf).

--- a/src/linearshrinkage.jl
+++ b/src/linearshrinkage.jl
@@ -1,7 +1,7 @@
 const Shrinkage = Union{Symbol, Real}
 abstract type LinearShrinkageTarget end
 
-# Taxonomy from http://strimmerlab.org/publications/journals/shrinkcov2005.pdf
+# Taxonomy from https://strimmerlab.github.io/publications/journals/shrinkcov2005.pdf
 # page 13
 
 """
@@ -213,7 +213,7 @@ end
     sum_fij(Xc, S, n, κ)
 
 Internal function corresponding to ``∑_{i≂̸j}f_{ij}`` that appears in
-http://strimmerlab.org/publications/journals/shrinkcov2005.pdf p.11.
+https://strimmerlab.github.io/publications/journals/shrinkcov2005.pdf p.11.
 
 * Space complexity: ``O(np + 2p^2)``
 * Time complexity: ``O(2np^2)``


### PR DESCRIPTION
strimmerlab.org has gone offline and been taken over by a gaming site.