### PR TITLE
Guard against coordinates with no variance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CovarianceEstimation"
 uuid = "587fd27a-f159-11e8-2dae-1979310e6154"
 authors = ["Mateusz Baran <mateuszbaran89@gmail.com>", "Thibaut Lienart"]
-version = "0.2.10"
+version = "0.2.11"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,3 +13,7 @@ end
 
 totalweight(n) = n
 totalweight(_, weights) = sum(weights)
+
+# Dividing by zero produces zero
+guardeddiv(num, denom) = iszero(denom) ? zero(num)/oneunit(denom) : num/denom
+diaginv(guard::Bool, num, v) = guard ? map(z -> guardeddiv(num, z), v) : num ./ v

--- a/test/test_linearshrinkage.jl
+++ b/test/test_linearshrinkage.jl
@@ -174,6 +174,10 @@ end
             LSEss = LinearShrinkage(target, :ss, corrected=c)
             LSElw = LinearShrinkage(target, :lw, corrected=c)
             c = cov(LSEss, Xcs); @test c ≈ cov(LSElw, Xcs); @test issymmetric(c)
+            # Adding a coordinate with no variance should not result in NaN entries
+            Xcs = [Xcs zeros(n, 1)]
+            c = cov(LSEss, Xcs; drop_var0=true);
+            @test all(isfinite, c); @test c ≈ cov(LSElw, Xcs; drop_var0=true); @test issymmetric(c)
             # Weight types besides FrequencyWeights are not supported
             aw1 = AnalyticWeights(rand(size(Xcs, 1)))
             @test_throws ErrorException cov(LSEss, Xcs, aw1)


### PR DESCRIPTION
This returns finite shrink-covariances even when one or more coordinates has zero variance.

This is marked WIP because there's one case in which the result is not invariant with respect to extra coordinates: nonlinear shrinkage with more data points than dimensions (`n > p`). I don't immediately see what needs to change to fix that, but I'm not familiar with that particular paper.
